### PR TITLE
Added become to gitlab_restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: restart gitlab
   command: gitlab-ctl reconfigure
   register: gitlab_restart
+  become: true
   failed_when: gitlab_restart_handler_failed_when
 
 - name: ssh restart


### PR DESCRIPTION
gitlab_restart handler was not working due to it requiring privileged access.  Added become to handler.